### PR TITLE
Clean imports

### DIFF
--- a/VedicAstroAPI.py
+++ b/VedicAstroAPI.py
@@ -1,7 +1,6 @@
 from typing import Optional
 from pydantic import BaseModel
 from fastapi import FastAPI
-from concurrent.futures import ThreadPoolExecutor
 from fastapi.middleware.cors import CORSMiddleware
 from vedicastro import VedicAstro, horary_chart, utils
 

--- a/vedicastro/VedicAstro.py
+++ b/vedicastro/VedicAstro.py
@@ -1,7 +1,7 @@
 from flatlib import const, aspects
 from flatlib.chart import Chart
 from flatlib.geopos import GeoPos
-from flatlib.datetime import Datetime, Date
+from flatlib.datetime import Datetime
 from flatlib.object import GenericObject
 from .utils import *
 from .utils import calculate_pada_from_zodiac


### PR DESCRIPTION
## Summary
- remove unused `ThreadPoolExecutor` from API
- drop unused `Date` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68410c8005048321a3f0131223b0fe62