### PR TITLE
Add KP house sublord helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ Thereafter, you can test the API service at `http://127.0.0.1:8088/docs` in your
 ## Front-End Companion Project
 If you are looking a front end project to visualize the results of the `VedicAstroAPI` call, please check out https://github.com/diliprk/AstroVue
 
+## KP Sublord Analysis Example
+The API now defaults to the **Placidus** house system. Use the helper class
+`HouseSignificatorEngine` to inspect cusp sub-lords directly from API data.
+
+```python
+from vedicastro.house_sublord_engine import HouseSignificatorEngine
+
+engine = HouseSignificatorEngine("Placidus", "horary", api_data)
+result = engine.analyze_sublords()
+```
+
+This logs the sub-lords for the 1st, 6th and 10th cusps and keeps the Moon's
+sub-lord separate for reference.
+
 ## Dedicatations
 This package is a dedication to the following great personalities, following in their footsteps:
 - [Parasara MahaRishi](https://en.wikipedia.org/wiki/Parashara)

--- a/VedicAstroAPI.py
+++ b/VedicAstroAPI.py
@@ -17,7 +17,7 @@ class ChartInput(BaseModel):
     latitude: float
     longitude: float
     ayanamsa: str = "Lahiri"
-    house_system: str = "Equal"
+    house_system: str = "Placidus"
     return_style: Optional[str] = None
 
 class HoraryChartInput(BaseModel):

--- a/vedicastro/__init__.py
+++ b/vedicastro/__init__.py
@@ -1,0 +1,13 @@
+"""Public package exports for VedicAstro."""
+
+from .VedicAstro import VedicHoroscopeData
+from .horary_chart import find_exact_ascendant_time, generate_basic_kp_chart
+from .house_sublord_engine import HouseSignificatorEngine
+
+__all__ = [
+    "VedicHoroscopeData",
+    "find_exact_ascendant_time",
+    "generate_basic_kp_chart",
+    "HouseSignificatorEngine",
+]
+

--- a/vedicastro/house_sublord_engine.py
+++ b/vedicastro/house_sublord_engine.py
@@ -1,0 +1,37 @@
+import logging
+
+class HouseSignificatorEngine:
+    """Simple engine to analyze KP cusp sub-lords."""
+
+    def __init__(self, house_system: str, query_type: str, api_data: dict):
+        self.house_system = house_system
+        self.query_type = query_type
+        self.api_data = api_data
+
+    def analyze_sublords(self) -> dict:
+        """Return sub-lords of 1st, 6th and 10th cusps.
+
+        Also captures the Moon sub-lord for context.
+        """
+        cusp_sublords = self.api_data["houses_data"]
+        first_sub = cusp_sublords[0]["SubLord"]
+        sixth_sub = cusp_sublords[5]["SubLord"]
+        tenth_sub = cusp_sublords[9]["SubLord"]
+
+        moon_info = [p for p in self.api_data["planets_data"] if p["Object"] == "Moon"][0]
+        moon_sublord = moon_info["SubLord"]
+
+        logging.info(
+            "Using %s: 1st sub-lord = %s, 6th = %s, 10th = %s",
+            self.house_system,
+            first_sub,
+            sixth_sub,
+            tenth_sub,
+        )
+
+        return {
+            "first_sub": first_sub,
+            "sixth_sub": sixth_sub,
+            "tenth_sub": tenth_sub,
+            "moon_sublord": moon_sublord,
+        }


### PR DESCRIPTION
## Summary
- default house system to Placidus in `ChartInput`
- export new `HouseSignificatorEngine`
- implement `HouseSignificatorEngine` for KP cusp sub-lords
- document usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f9cfaab208321a5684e2e278cad13